### PR TITLE
Add batctl-plasma to Community Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ batctl/
 ## Community Projects
 
 
+- **[batctl-plasma](https://github.com/BorisLord/batctl-plasma)** — Native Plasma 6 GUI for batctl
 - **[threshpad](https://github.com/looselyhuman/threshpad)** — GNOME Shell extension for batctl
 
 ## Contributing


### PR DESCRIPTION
Adds [batctl-plasma](https://github.com/BorisLord/batctl-plasma)
KDE Plasma 6 panel widget that wraps `batctl status` and `batctl set --preset`